### PR TITLE
Make the plugin path an environment variable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,6 +2,7 @@
 # If you're using Docker, just leave these as their default values
 systemPath = "/fritz" # Path to the project folder
 resourcePath = "/app/resources" # Path to the resources folder
+pluginPath = "/plugins" # Path to the plugins folder
 ptkPath = "/ptk" # Path to PtK's resources. Leave blank if you don't have these
 
 # URLs #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build: .
     volumes:
       - ./config:/fritz/config
+      - ./plugins:/plugins
       - ./cache:/fritz/cache
       - ./logs:/fritz/logs
       - ./ptk:/ptk

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ import sys
 from resources.shared import CONTEXTS, CONTEXTS_SERVER_ONLY, INTEGRATION_TYPES, INTEGRATION_TYPES_SERVER_ONLY
 from resources.shared import BLACKLISTED_USERS, DISALLOW_SYSINF_LEAKS, DISALLOW_PLATFORM_LEAKS, GIT_URL, IS_ANDROID
 from resources.shared import IS_DEBUGGING, VERSION, TOKEN, REGISTERED_DEVELOPERS, INVITE_URL
-from resources.shared import ENABLE_QUOTEBOOK, ENABLE_IMPORTED_PLUGINS, PATH, BOOTID
+from resources.shared import ENABLE_QUOTEBOOK, ENABLE_IMPORTED_PLUGINS, PATH, PLUGIN_PATH, BOOTID
 from resources.responses import help_messages
 
 from resources.colour import RED, DRIVES, YELLOW, SPECIALDRIVE, BLUE, RESET, MAGENTA, SEAFOAM
@@ -400,18 +400,18 @@ if ENABLE_IMPORTED_PLUGINS:
 		open(f"{PATH}/cache/HAS_SEEN_PLUGIN_WARNING", "x").close()
 
 	# First, make sure the plugin directory exists
-	if os.path.exists(f"{PATH}/plugins"):
-		plugins_to_import = os.listdir(f"{PATH}/plugins")
+	if os.path.exists(PLUGIN_PATH):
+		plugins_to_import = os.listdir(PLUGIN_PATH)
 
 		for module in plugins_to_import:
 			# Check to make sure the file isn't blacklisted
-			if os.path.isdir(f"{PATH}/plugins/{module}") or ".env" in module:
+			if os.path.isdir(PLUGIN_PATH + f"/{module}") or ".env" in module:
 				pass
 
 			else:
 				try:
 					# This is a huge security violation
-					exec(open(f"{PATH}/plugins/{module}").read())
+					exec(open(PLUGIN_PATH + f"/{module}").read())
 
 					try:
 						t1, t2, t3 = _funchook()

--- a/resources/shared.py
+++ b/resources/shared.py
@@ -100,7 +100,8 @@ CONTEXTS_SERVER_ONLY = {discord.InteractionContextType.guild}
 INTEGRATION_TYPES_SERVER_ONLY = {discord.IntegrationType.guild_install}
 
 PATH = os.getenv("systemPath", sys.path[0])
-RESOURCE_PATH = os.getenv("resourcePath", sys.path[0] + "/resources")
+RESOURCE_PATH = os.getenv("resourcePath", PATH + "/resources")
+PLUGIN_PATH = os.getenv("pluginPath", PATH + "/plugins")
 
 # Module availability
 ENABLE_QUOTEBOOK = True if QUOTE_WEBHOOK != "" and QUOTE_ID != "" else False


### PR DESCRIPTION
This is just another thing that's a little different with Docker. Also switches up the Docker Compose file a bit so that the plugins can be loaded at runtime (should hopefully allow for dynamically reloading plugins in the future).