### PR TITLE
Add Command Prefix to Environment

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -15,6 +15,8 @@ block_sysinf_leaks = True # Prevents users not in REGISTERED_DEVELOPERS from usi
 hide_platform = True # Hide what platform Fritz is running on. Only applies to Discord - console will still show the platform
 enable_plugins = False # Determines whether the plugins folder will be scanned and imported
 log_level = "INFO" # Any messages above this level will be logged.
+fritz_prefix = "f" # The prefix for Fritz's genaric commands. 
+fritz_prefix_dev = "f_dev" # The prefix for Fritz's developer-only utilities
 
 # Core API #
 applicationID = "application ID" # Discord application ID

--- a/main.py
+++ b/main.py
@@ -51,8 +51,10 @@ loop = asyncio.get_event_loop()
 nest_asyncio.apply(loop)
 
 ### COMMAND GROUPS ###
-fritz = bot.create_group("f",          "Fritz's generic commands",           contexts=CONTEXTS,         integration_types=INTEGRATION_TYPES)
-zdev  = bot.create_group("f_dev",      "Developer-only utilities",           contexts=CONTEXTS,         integration_types=INTEGRATION_TYPES)
+fritz = bot.create_group(os.getenv("fritz_prefix", "f"),          "Fritz's generic commands",           contexts=CONTEXTS,         integration_types=INTEGRATION_TYPES)
+zdev  = bot.create_group(os.getenv("fritz_prefix_dev", "f_dev"),      "Developer-only utilities",           contexts=CONTEXTS,         integration_types=INTEGRATION_TYPES)
+if not os.getenv("fritz_prefix") or not os.getenv("fritz_prefix_dev"):
+	journal.log("Missing command prefix in environment, using default.")
 
 if not qrTools.NOQR:
 	qr    = bot.create_group("qr",         "Tools relating to QR codes",         contexts=CONTEXTS,         integration_types=INTEGRATION_TYPES)


### PR DESCRIPTION
Move the command prefix to an environment variable so development bots can be easily accessed. 